### PR TITLE
Fix incorrect buildpack github path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Example usage:
     $ heroku config:add BUILDPACK_URL=https://github.com/ddollar/heroku-buildpack-multi.git
 
     $ cat .buildpacks
-    https://github.com/heroku/heroku-buildpack-pgbouncer.git#v0.2
+    https://github.com/gregburek/heroku-buildpack-pgbouncer.git#v0.2.1
     https://github.com/heroku/heroku-buildpack-ruby.git
 
     $ cat Procfile


### PR DESCRIPTION
Great package!  Its working well for me.  

Fixes the buildpack url in the README to be gregburek/heroku-buildpack-pgbouncer instead of heroku/heroku-buildpack-pgbouncer, which doesn't exist.
