### PR TITLE
Update readme to include fixes for rails 3.2.x.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Disable Prepared Statements
 With Rails 4.1, you can disable prepared statements by appending `?prepared_statements=false` to the database's URI.
 Set the `PGBOUNCER_PREPARED_STATEMENTS` config var to `false` for the buildpack to do that for you.
 
-For Rails 3.2 - 4.0 you will first need to apply a simplified backport of [this commit](https://github.com/rails/rails/commit/e54acf1308e2e4df047bf90798208e03e1370098). Just create a new ruby file in `config/initializers` with the following content:
+Rails 3.2 - 4.0 also requires an initializer to properly cast the prepared_statements configuration string as a boolean. This initializer is adapted from [this commit](https://github.com/rails/rails/commit/e54acf1308e2e4df047bf90798208e03e1370098). In file config/initializers/database_connection.rb insert the following:
 
 ```ruby
 require "active_record/connection_adapters/postgresql_adapter"
@@ -45,8 +45,6 @@ class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
   end
 end
 ```
-
-and follow the instructions for Rails 4.1.
 
 
 Usage


### PR DESCRIPTION
We hit this issue while trying to use the buildpack with a rails 3.2 app. No matter what we did, in the heroku environment prepared statements were still being generated, and our staging server became a mountain of error messages.

Rails ignores the database.yml when DATABASE_URL is defined, but rails 3.2.x does not correctly parse `prepared_statements=false`.

`prepared_statements=false` is evaluated to `{prepared_statements: "false"}`, rather than `{prepared_statements: false}`. The string `"false"` evaluates to `true`, so prepared statements are not disabled correctly.

The monkey patch filters the config options hash, and correctly maps the `"false"` to `false`.
