### PR TITLE
Fix quoting of $@ and don't exec in the background.

### DIFF
--- a/bin/start-pgbouncer-stunnel
+++ b/bin/start-pgbouncer-stunnel
@@ -23,9 +23,8 @@ mkfifo $psmgr
 (
 	#Take the command passed to this bin and start it.
 	#E.g. bin/start-pgbouncer-stunnel bundle exec unicorn -c config/unicorn.rb
-	exec $@ &
-	echo "buildpack=pgbouncer at=start-app cmd=$@"
-	wait
+	echo "buildpack=pgbouncer at=app-start cmd=$*"
+	"$@"
 	echo 'app' >$psmgr
 ) &
 


### PR DESCRIPTION
"$@" expands to "$1" "$2" "$3" which preserves spaces calling the chained
command.

"$*" expands to "$1 $2 $3" which makes sense for the echo argument.

This commit also switches to simply calling the chained command in the 
foreground, instead of exec in the background with wait which is a complicated
way of doing nothing.
