### PR TITLE
Overhaul to handle SIGTERM properly.

### DIFF
--- a/bin/start-pgbouncer-stunnel
+++ b/bin/start-pgbouncer-stunnel
@@ -56,7 +56,7 @@ run-pgbouncer() {
   # Kill the auxiliary processes.
   # Send each one SIGHUP which will be translated by the trap in aux-start.
   declare name
-  for name in "${!pids[*]}"; do
+  for name in "${!pids[@]}"; do
     at "kill-aux name=$name pid=${pids[$name]} signal=${signals[$name]}"
     kill -SIGHUP "${pids[$name]}"
   done


### PR DESCRIPTION
I found that our attempted top-level trap was preventing the app from receiving SIGTERM for orderly shutdown of the dyno. After some experimentation, here's what I came up with. See https://gist.github.com/agriffis/9798319 for my test script. (You can run it on the command-line with values for $1 and $2 to see how the overall manager behaves when processes die by various causes.)

I'm using this now on deployed servers.
