### PR TITLE
adds stats_users config for admin console access

### DIFF
--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -52,6 +52,7 @@ log_connections = ${PGBOUNCER_LOG_CONNECTIONS:-1}
 log_disconnections = ${PGBOUNCER_LOG_DISCONNECTIONS:-1}
 log_pooler_errors = ${PGBOUNCER_LOG_POOLER_ERRORS:-1}
 stats_period = ${PGBOUNCER_STATS_PERIOD:-60}
+stats_users = ${DB_USER}
 [databases]
 EOFEOF
 


### PR DESCRIPTION
adds `stats_users` config for pgbouncer admin console access
http://pgbouncer.projects.pgfoundry.org/doc/usage.html#_admin_console

