### PR TITLE
adding setting for ignore_startup_parameters

### DIFF
--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -52,6 +52,7 @@ log_connections = ${PGBOUNCER_LOG_CONNECTIONS:-1}
 log_disconnections = ${PGBOUNCER_LOG_DISCONNECTIONS:-1}
 log_pooler_errors = ${PGBOUNCER_LOG_POOLER_ERRORS:-1}
 stats_period = ${PGBOUNCER_STATS_PERIOD:-60}
+ignore_startup_parameters = ${PGBOUNCER_IGNORE_STARTUP_PARAMS:-false}
 [databases]
 EOFEOF
 

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -52,7 +52,7 @@ log_connections = ${PGBOUNCER_LOG_CONNECTIONS:-1}
 log_disconnections = ${PGBOUNCER_LOG_DISCONNECTIONS:-1}
 log_pooler_errors = ${PGBOUNCER_LOG_POOLER_ERRORS:-1}
 stats_period = ${PGBOUNCER_STATS_PERIOD:-60}
-ignore_startup_parameters = ${PGBOUNCER_IGNORE_STARTUP_PARAMS:-false}
+ignore_startup_parameters = ${PGBOUNCER_IGNORE_STARTUP_PARAMS}
 [databases]
 EOFEOF
 


### PR DESCRIPTION
The JVM passes 'extra_float_digits' as a startup param and needs to be ignored for jruby to work.  This just allows the config of ignore_startup_parameters from command line params.  See: http://pgbouncer.projects.pgfoundry.org/doc/config.html#_generic_settings