### PR TITLE
config option for stunnel logging level

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ and [stunnel](http://linux.die.net/man/8/stunnel) configurations to see what set
 - `PGBOUNCER_LOG_POOLER_ERRORS` Default is 1
 - `PGBOUNCER_STATS_PERIOD` Default is 60
 - `PGBOUNCER_SERVER_RESET_QUERY` Default is empty when pool mode is transaction, and "DISCARD ALL;" when session.
-
+- `PGBOUNCER_STUNNEL_LOGLEVEL` Default is notice (5). Set this var to pass a syslog level name or number value to stunnel.  This corresponds to the stunnel global configuration option called "debug".
 - `ENABLE_STUNNEL_AMAZON_RDS_FIX` Default is unset. Set this var if you are connecting to an Amazon RDS instance of postgres.
  Adds `options = NO_TICKET` which is documented to make stunnel work correctly after a dyno resumes from sleep. Otherwise, the dyno will lose connectivity to RDS.
 

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -29,6 +29,7 @@ socket = r:TCP_NODELAY=1
 options = NO_SSLv3
 ${AMAZON_RDS_STUNNEL_OPTION}
 ciphers = HIGH:!ADH:!AECDH:!LOW:!EXP:!MD5:!3DES:!SRP:!PSK:@STRENGTH
+debug = ${PGBOUNCER_STUNNEL_LOGLEVEL:-notice}
 EOFEOF
 
 cat >> /app/vendor/pgbouncer/pgbouncer.ini << EOFEOF


### PR DESCRIPTION
The default stunnel loglevel is "notice", which is a bit too verbose for my taste (it logs messages every time a connection is created or disconnected).  

This PR adds another config environment variable (`PGBOUNCER_STUNNEL_LOGLEVEL`) which can be set in order to pass a non-default value to the stunnel config.

The default remains "notice", so unless this environment variable is set, this PR does not change the buildpack's behavior at all.