### PR TITLE
ensure clean config files

### DIFF
--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -19,6 +19,10 @@ else
 fi
 
 mkdir -p /app/vendor/stunnel/var/run/stunnel/
+rm -f /app/vendor/stunnel/stunnel-pgbouncer.conf
+rm -f /app/vendor/pgbouncer/pgbouncer.ini
+rm -f /app/vendor/pgbouncer/users.txt
+
 cat >> /app/vendor/stunnel/stunnel-pgbouncer.conf << EOFEOF
 foreground = yes
 


### PR DESCRIPTION
The `gen-pgbouncer-conf.sh` script creates 3 config files -- but always uses the append operator  (`>>`) to do so.  This is fine most of the time, but for example if someone creates a one-off instance to test something, and winds up running `bin/start-pgbouncer-stunnel` more than once (which calls `gen-pgbouncer-conf.sh`), then invalid config files wind up being creted for subsequent runs.

This PR fixes the issue by explicitly removing the 3 config files before any append operations, ensuring a clean start.