### PR TITLE
add pgbouncer to admin_users users (enable admin console)

### DIFF
--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -56,6 +56,7 @@ log_connections = ${PGBOUNCER_LOG_CONNECTIONS:-1}
 log_disconnections = ${PGBOUNCER_LOG_DISCONNECTIONS:-1}
 log_pooler_errors = ${PGBOUNCER_LOG_POOLER_ERRORS:-1}
 stats_period = ${PGBOUNCER_STATS_PERIOD:-60}
+admin_users = pgbouncer
 [databases]
 EOFEOF
 

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -98,5 +98,12 @@ EOFEOF
   let "n += 1"
 done
 
+DB_USER=pgbouncer
+DB_PASS=pgbouncer
+DB_MD5_PASS="md5"`echo -n ${DB_PASS}${DB_USER} | md5sum | awk '{print $1}'`
+cat >> /app/vendor/pgbouncer/users.txt << EOFEOF
+"$DB_USER" "$DB_MD5_PASS"
+EOFEOF
+
 chmod go-rwx /app/vendor/pgbouncer/*
 chmod go-rwx /app/vendor/stunnel/*


### PR DESCRIPTION
This is a follow-up to #62 and #71.

The use case here is deploying a monitor process on each dyno that connects to the stats interface, queries it periodically, and posts the metrics to some sort of metrics aggregator.

This patch adds a user with username `pgbouncer` and password `pgbouncer`, which can be reached on `127.0.0.1:6000`.

Example connection:

    $ PGPASSWORD=pgbouncer psql -h 127.0.0.1 -p 6000 -U pgbouncer pgbouncer

    pgbouncer=# show pools;

         database  |   user    | cl_active | cl_waiting | sv_active | sv_idle | sv_used | sv_tested | sv_login | 
    maxwait | pool_mode
    -----------+-----------+-----------+------------+-----------+---------+---------+-----------+----------+---------+-----------
     pgbouncer | pgbouncer |         1 |          0 |         0 |       0 |       0 |         0 |        0 |       0 | statement
    (1 row)

Here is an example of how it is intended to be used: https://github.com/travis-ci/travis-api/pull/488.