### PR TITLE
Fixed issue which fails DATABASE_URL parsing, if no password is provided

### DIFF
--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -19,7 +19,7 @@ else
 fi
 
 mkdir -p /app/vendor/stunnel/var/run/stunnel/
-cat >> /app/vendor/stunnel/stunnel-pgbouncer.conf << EOFEOF
+cat > /app/vendor/stunnel/stunnel-pgbouncer.conf << EOFEOF
 foreground = yes
 
 options = NO_SSLv2
@@ -32,7 +32,7 @@ ciphers = HIGH:!ADH:!AECDH:!LOW:!EXP:!MD5:!3DES:!SRP:!PSK:@STRENGTH
 debug = ${PGBOUNCER_STUNNEL_LOGLEVEL:-notice}
 EOFEOF
 
-cat >> /app/vendor/pgbouncer/pgbouncer.ini << EOFEOF
+cat > /app/vendor/pgbouncer/pgbouncer.ini << EOFEOF
 [pgbouncer]
 listen_addr = 127.0.0.1
 listen_port = 6000
@@ -86,7 +86,7 @@ connect = $DB_HOST:$DB_PORT
 retry = ${PGBOUNCER_CONNECTION_RETRY:-"no"}
 EOFEOF
 
-  cat >> /app/vendor/pgbouncer/users.txt << EOFEOF
+  cat > /app/vendor/pgbouncer/users.txt << EOFEOF
 "$DB_USER" "$DB_MD5_PASS"
 EOFEOF
 

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -62,7 +62,7 @@ EOFEOF
 for POSTGRES_URL in $POSTGRES_URLS
 do
   eval POSTGRES_URL_VALUE=\$$POSTGRES_URL
-  IFS=':' read DB_USER DB_PASS DB_HOST DB_PORT DB_NAME <<< $(echo $POSTGRES_URL_VALUE | perl -lne 'print "$1:$2:$3:$4:$5" if /^postgres(?:ql)?:\/\/([^:]*):([^@]*)@(.*?):(.*?)\/(.*?)$/')
+  IFS=':' read DB_USER DB_PASS DB_HOST DB_PORT DB_NAME <<< $(echo $POSTGRES_URL_VALUE | perl -lne 'print "$1:$2:$3:$4:$5" if /^postgres(?:ql)?:\/\/([^:]*)(?::([^@]*))?@(.*?):(.*?)\/(.*?)$/')
 
   DB_MD5_PASS="md5"`echo -n ${DB_PASS}${DB_USER} | md5sum | awk '{print $1}'`
 


### PR DESCRIPTION
Separated from #83, as requested.

Fixed issue which fails DATABASE_URL parsing, if no password is provided.

The regex parse will now work, if no password is provided in the DATABASE_URL. The only change to the regex makes the password optional as well as the colon immediately before it.

This is needed for local environment testing where I don't use a database password.