### PR TITLE
Fix appending users.txt which broke in #83

### DIFF
--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -86,7 +86,7 @@ connect = $DB_HOST:$DB_PORT
 retry = ${PGBOUNCER_CONNECTION_RETRY:-"no"}
 EOFEOF
 
-  cat > /app/vendor/pgbouncer/users.txt << EOFEOF
+  cat >> /app/vendor/pgbouncer/users.txt << EOFEOF
 "$DB_USER" "$DB_MD5_PASS"
 EOFEOF
 


### PR DESCRIPTION
The users.txt file must be appended to as multiple postgres dbs in
POSTGRES_URLS, we need to add all the creds to the users.txt file, not
reset it for every entry in POSTGRES_URLS.