### PR TITLE
introduce PGBOUNCER_CONNECT_QUERY parameter to configure connect_query setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,5 +146,6 @@ and [stunnel](http://linux.die.net/man/8/stunnel) configurations to see what set
 - `ENABLE_STUNNEL_AMAZON_RDS_FIX` Default is unset. Set this var if you are connecting to an Amazon RDS instance of postgres.
  Adds `options = NO_TICKET` which is documented to make stunnel work correctly after a dyno resumes from sleep. Otherwise, the dyno will lose connectivity to RDS.
 - `PGBOUNCER_IGNORE_STARTUP_PARAMETERS` Adds parameters to ignore when pgbouncer is starting. Some postgres libraries, like Go's pq, append this parameter, making it impossible to use this buildpack. Default is empty and the most common ignored parameter is `extra_float_digits`. Multiple parameters can be seperated via commas. Example: `PGBOUNCER_IGNORE_STARTUP_PARAMETERS="extra_float_digits, some_other_param"`
+- `PGBOUNCER_CONNECT_QUERY` The query to be executed on newly created connections. This is useful for setting things like `statement_timeout`. e.g. `PGBOUNCER_CONNECT_QUERY="set statement_timeout to 10000"`
 
 For more info, see [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -93,7 +93,7 @@ EOFEOF
 EOFEOF
 
   cat >> /app/vendor/pgbouncer/pgbouncer.ini << EOFEOF
-$CLIENT_DB_NAME= dbname=$DB_NAME port=610${n} connect_query='${PGBOUNCER_CONNECT_QUERY}'
+$CLIENT_DB_NAME= dbname=$DB_NAME port=610${n} connect_query='${PGBOUNCER_CONNECT_QUERY//\'/\'\'}'
 EOFEOF
 
   let "n += 1"

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -93,7 +93,7 @@ EOFEOF
 EOFEOF
 
   cat >> /app/vendor/pgbouncer/pgbouncer.ini << EOFEOF
-$CLIENT_DB_NAME= dbname=$DB_NAME port=610${n}
+$CLIENT_DB_NAME= dbname=$DB_NAME port=610${n} connect_query='${PGBOUNCER_CONNECT_QUERY}'
 EOFEOF
 
   let "n += 1"

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -92,8 +92,13 @@ EOFEOF
 "$DB_USER" "$DB_MD5_PASS"
 EOFEOF
 
+CONNECT_QUERY_PARAM=''
+if [[ "$PGBOUNCER_CONNECT_QUERY" ]]; then
+  CONNECT_QUERY_PARAM="connect_query='${PGBOUNCER_CONNECT_QUERY//\'/\'\'}'"
+fi
+
   cat >> /app/vendor/pgbouncer/pgbouncer.ini << EOFEOF
-$CLIENT_DB_NAME= dbname=$DB_NAME port=610${n} connect_query='${PGBOUNCER_CONNECT_QUERY//\'/\'\'}'
+$CLIENT_DB_NAME= dbname=$DB_NAME port=610${n} $CONNECT_QUERY_PARAM
 EOFEOF
 
   let "n += 1"


### PR DESCRIPTION
TLDR: this is super useful for setting things like statement_timeout on backend connection initiation.

Backstory:

We are running pgbouncer in statement pooling mode. We were setting `statement_timeout` on connection start in activerecord, to make sure we don't have lingering long-running queries. But for some reason we had a really bad query almost take down the database, so we started to investigate.

Long story short: As soon as pgbouncer re-creates its connections (by default at least once every hour), they do not have `statement_timeout` (and other session-level props) set.

This patch allows defining a query to execute after pgbouncer creates a new backend connection.