### PR TITLE
Add query_wait_timeout configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,5 +146,6 @@ and [stunnel](http://linux.die.net/man/8/stunnel) configurations to see what set
 - `ENABLE_STUNNEL_AMAZON_RDS_FIX` Default is unset. Set this var if you are connecting to an Amazon RDS instance of postgres.
  Adds `options = NO_TICKET` which is documented to make stunnel work correctly after a dyno resumes from sleep. Otherwise, the dyno will lose connectivity to RDS.
 - `PGBOUNCER_IGNORE_STARTUP_PARAMETERS` Adds parameters to ignore when pgbouncer is starting. Some postgres libraries, like Go's pq, append this parameter, making it impossible to use this buildpack. Default is empty and the most common ignored parameter is `extra_float_digits`. Multiple parameters can be seperated via commas. Example: `PGBOUNCER_IGNORE_STARTUP_PARAMETERS="extra_float_digits, some_other_param"`
+- `PGBOUNCER_QUERY_WAIT_TIMEOUT` Default is 120 seconds, helps when the server is down or the database rejects connections for any reason. If this is disabled, clients will be queued infinitely.
 
 For more info, see [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -57,6 +57,7 @@ log_disconnections = ${PGBOUNCER_LOG_DISCONNECTIONS:-1}
 log_pooler_errors = ${PGBOUNCER_LOG_POOLER_ERRORS:-1}
 stats_period = ${PGBOUNCER_STATS_PERIOD:-60}
 ignore_startup_parameters = ${PGBOUNCER_IGNORE_STARTUP_PARAMETERS}
+query_wait_timeout = ${PGBOUNCER_QUERY_WAIT_TIMEOUT:-120}
 
 [databases]
 EOFEOF


### PR DESCRIPTION
This commit adds the `query_wait_timeout` configuration option
and associated `PGBOUNCER_QUERY_WAIT_TIMEOUT` env var for
configuration, in order to allow customisation of this option.

Default is set to 120 seconds, as per PgBouncer default.