### PR TITLE
Using exec in stunnel wrapper script

### DIFF
--- a/bin/start-pgbouncer-stunnel
+++ b/bin/start-pgbouncer-stunnel
@@ -9,7 +9,7 @@ main() {
   echo "Using bin/start-pgbouncer-stunnel, which is a deprecated init script. Use bin/start-pgbouncer instead."
   echo ""
 
-  bin/start-pgbouncer "$@"
+  exec bin/start-pgbouncer "$@"
 }
 
 [[ "$0" != "$BASH_SOURCE" ]] || main "$@"


### PR DESCRIPTION
The wrapper script was previously creating a child process which messed up our signal trapping. Running `exec` should replace the current process with `bin/start-pgbouncer` which will trap kill signals and not exit until all of the child processes have exited.

The issue was that the wrapper script was creating `bin/start-pgbouncer` as a child process and not trapping any signals. Without the wrapper script `bin/start-pgbouncer` will trap signals, forward them to children, and wait until they have all exited cleanly before dying.

Should address https://github.com/heroku/heroku-buildpack-pgbouncer/issues/109.