### PR TITLE
Allow SSL connection by client app

### DIFF
--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -20,6 +20,7 @@ auth_file = /app/vendor/pgbouncer/users.txt
 server_tls_sslmode = prefer
 server_tls_protocols = secure
 server_tls_ciphers = HIGH:!ADH:!AECDH:!LOW:!EXP:!MD5:!3DES:!SRP:!PSK:@STRENGTH
+client_tls_sslmode = allow
 
 ; When server connection is released back to pool:
 ;   session      - after client disconnects


### PR DESCRIPTION
Allow the application to connect to pgBouncer with SSL. THIS PATCH DOES NOT PROVIDE SECURITY: no certificate is checked.

This is useful if you application or its dependencies require SSL to the database. (For example the New Relic agent.)