### PR TITLE
Overhaul development tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,14 @@ Install [docker](https://www.docker.com/). Use the Get Started button at the
 top of the page, which autodetects your OS and presents the appropriate
 instructions.
 
-Build:
-
+Build for all stacks:
 ```
-$ cd support
-$ docker-compose build
-$ docker-compose up
+$ make build
+```
+
+Build for a specific stack:
+```
+$ make build-$STACK
 ```
 
 ## Publishing buildpack updates

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## unreleased
+
+* Updates development tooling
+
 ## v0.3.4 (January 2, 2015)
 
 * Updates binary versions to pgbouncer 1.7 and stunnel 5.28

--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,5 @@ build-heroku-18:
 	@docker run -v $(shell pwd):/buildpack --rm -it -e "STACK=heroku-18" -e "PGBOUNCER_VERSION=1.8.1" -w /buildpack heroku/heroku:18-build support/pgbouncer-build
 
 shell:
-	@echo "Opening heroku-16 shell..."
-	@docker run -v $(shell pwd):/buildpack --rm -it -e "STACK=heroku-16" -e "PORT=5000" -w /buildpack heroku/heroku:16 bash
+	@echo "Opening heroku-18 shell..."
+	@docker run -v $(shell pwd):/buildpack --rm -it -e "STACK=heroku-18" -e "PORT=5000" -w /buildpack heroku/heroku:18 bash

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+build: build-cedar-14 build-heroku-16 build-heroku-18
+
+build-cedar-14:
+	@echo "Building pgbouncer in Docker for cedar-14..."
+	@docker run -v $(shell pwd):/buildpack --rm -it -e "STACK=cedar-14" -e "PGBOUNCER_VERSION=1.7" -w /buildpack heroku/cedar:14 support/pgbouncer-build
+
+build-heroku-16:
+	@echo "Building pgbouncer in Docker for heroku-16..."
+	@docker run -v $(shell pwd):/buildpack --rm -it -e "STACK=heroku-16" -e "PGBOUNCER_VERSION=1.7.2" -w /buildpack heroku/heroku:16-build support/pgbouncer-build
+
+build-heroku-18:
+	@echo "Building pgbouncer in Docker for heroku-18..."
+	@docker run -v $(shell pwd):/buildpack --rm -it -e "STACK=heroku-18" -e "PGBOUNCER_VERSION=1.8.1" -w /buildpack heroku/heroku:18-build support/pgbouncer-build
+
+shell:
+	@echo "Opening heroku-16 shell..."
+	@docker run -v $(shell pwd):/buildpack --rm -it -e "STACK=heroku-16" -e "PORT=5000" -w /buildpack heroku/heroku:16 bash

--- a/support/Dockerfile
+++ b/support/Dockerfile
@@ -1,7 +1,0 @@
-FROM heroku/heroku:16-build
-MAINTAINER gregburek
-
-ADD pgbouncer-build pgbouncer-build
-ADD 0001-Disable-SIGTERM.patch pgbouncer-patch
-
-CMD ./pgbouncer-build

--- a/support/docker-compose.yml
+++ b/support/docker-compose.yml
@@ -1,7 +1,0 @@
-pgbouncer-builder:
-  build: .
-  environment:
-    PGBOUNCER_VERSION: "1.7.2"
-  command: bash -c './pgbouncer-build'
-  volumes:
-    - ..:/external

--- a/support/pgbouncer-build
+++ b/support/pgbouncer-build
@@ -1,19 +1,25 @@
+#!/bin/bash
+
 set -e
 
 PGBOUNCER_VERSION=${PGBOUNCER_VERSION-1.7.2}
 
 pgbouncer_tarball_url=https://pgbouncer.github.io/downloads/files/${PGBOUNCER_VERSION}/pgbouncer-${PGBOUNCER_VERSION}.tar.gz
 
+temp_dir=$(mktemp -d /tmp/pgbouncer.XXXXXXXXXX)
+
+cd $temp_dir
+echo "Temp dir: $temp_dir"
+
 echo "Downloading $pgbouncer_tarball_url"
 curl -L $pgbouncer_tarball_url | tar xzv
 
 (
-    cd pgbouncer-${PGBOUNCER_VERSION}
-    git apply /pgbouncer-patch
+  cd pgbouncer-${PGBOUNCER_VERSION}
+  git apply /buildpack/support/0001-Disable-SIGTERM.patch
     ./configure \
-        --prefix=/app/vendor/pgbouncer
-    make
-    make install
+      --prefix=/tmp/pgbouncer
+  make -j 2 install
 )
 
-tar -zcvf /external/pgbouncer-${PGBOUNCER_VERSION}-heroku.tgz -C /app/vendor/pgbouncer .
+tar -zcvf /buildpack/pgbouncer-${PGBOUNCER_VERSION}-heroku.tgz -C /tmp/pgbouncer .


### PR DESCRIPTION
hey everybody,

this PR provides some streamlining for the development and building process. it cuts down depdencies for development to just docker (without docker-compose) and running one command gives you the complete archive in the correct folder. this also makes it easier to add new stacks and change versions for certain stacks.

additionally i like to mirror the tooling across our buildpacks. this approachs mirrors how we build nginx https://www.github.com/heroku/heroku-buildpack-nginx

i rebuilt pgbouncer 1.7.2 and verified the new tooling on a personal test app.

let me know what you think.

cheers
ben