### PR TITLE
fix: validate PGBOUNCER_URLS on config gen

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 ## Unreleased
 * Converted our remaining CircleCI tests to Github Actions
+* Add validation for PGBOUNCER_URLS
 
 ## v0.13.0 (September 9, 2022)
 * Update pgbouncer to v1.17.0 for Heroku-18 and Heroku-20 (for parity with Heroku-22)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ It is possible to connect to multiple databases through pgbouncer by setting
     HEROKU_POSTGRESQL_ROSE_URL=postgres://u9dih9htu2t3ll:password@127.0.0.1:6000/db2
     DATABASE_URL=postgres://uf2782hv7b3uqe:password@127.0.0.1:6000/db1
 
-> ⚠️ A referenced configuration variable in `PGBOUNCER_URLS` must not be empty, or otherwise must be a valid PostgreSQL connection string.
+> ⚠️ A referenced configuration variable in `PGBOUNCER_URLS` must not be empty, and must be a valid PostgreSQL connection string.
 
 ## Follower Replica Databases
 As of v0.3.2 of this buildpack, it is possible to use pgbouncer to connect to

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ It is possible to connect to multiple databases through pgbouncer by setting
     HEROKU_POSTGRESQL_ROSE_URL=postgres://u9dih9htu2t3ll:password@127.0.0.1:6000/db2
     DATABASE_URL=postgres://uf2782hv7b3uqe:password@127.0.0.1:6000/db1
 
+> ⚠️ A referenced configuration variable in `PGBOUNCER_URLS` must not be empty, or otherwise must be a valid PostgreSQL connection string.
+
 ## Follower Replica Databases
 As of v0.3.2 of this buildpack, it is possible to use pgbouncer to connect to
 multiple databases that share a database name, such as a leader and follower.

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -3,20 +3,24 @@
 POSTGRES_URLS=${PGBOUNCER_URLS:-DATABASE_URL}
 POOL_MODE=${PGBOUNCER_POOL_MODE:-transaction}
 SERVER_RESET_QUERY=${PGBOUNCER_SERVER_RESET_QUERY}
+CONFIG_DIR=${PGBOUNCER_CONFIG_DIR:-/app/vendor/pgbouncer}
 n=1
+
+set -eo pipefail
 
 # if the SERVER_RESET_QUERY and pool mode is session, pgbouncer recommends DISCARD ALL be the default
 # http://pgbouncer.projects.pgfoundry.org/doc/faq.html#_what_should_my_server_reset_query_be
 if [ -z "${SERVER_RESET_QUERY}" ] &&  [ "$POOL_MODE" == "session" ]; then
+  echo "SERVER_RESET_QUERY EMPTY"
   SERVER_RESET_QUERY="DISCARD ALL;"
 fi
 
-cat >> /app/vendor/pgbouncer/pgbouncer.ini << EOFEOF
+cat >> "$CONFIG_DIR/pgbouncer.ini" << EOFEOF
 [pgbouncer]
 listen_addr = 127.0.0.1
 listen_port = 6000
 auth_type = md5
-auth_file = /app/vendor/pgbouncer/users.txt
+auth_file = $CONFIG_DIR/users.txt
 server_tls_sslmode = prefer
 server_tls_protocols = secure
 server_tls_ciphers = HIGH:!ADH:!AECDH:!LOW:!EXP:!MD5:!3DES:!SRP:!PSK:@STRENGTH
@@ -81,15 +85,15 @@ do
     export "${POSTGRES_URL}"_PGBOUNCER=postgres://"$DB_USER":"$DB_PASS"@127.0.0.1:6000/$CLIENT_DB_NAME
   fi
 
-  cat >> /app/vendor/pgbouncer/users.txt << EOFEOF
+  cat >> "$CONFIG_DIR/users.txt" << EOFEOF
 "$DB_USER" "$DB_MD5_PASS"
 EOFEOF
 
-  cat >> /app/vendor/pgbouncer/pgbouncer.ini << EOFEOF
+  cat >> "$CONFIG_DIR/pgbouncer.ini" << EOFEOF
 $CLIENT_DB_NAME= host=$DB_HOST dbname=$DB_NAME port=$DB_PORT
 EOFEOF
 
   (( n += 1 ))
 done
 
-chmod go-rwx /app/vendor/pgbouncer/*
+chmod go-rwx "$CONFIG_DIR"/*

--- a/test/gen-pgbouncer-conf.bats
+++ b/test/gen-pgbouncer-conf.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+load helper
+
+setup_file() {
+    export PGBOUNCER_CONFIG_DIR=$(mktemp -d run-test-pgbouncer.XXXXXXXXXX)
+}
+
+teardown_file() {
+    unset PGBOUNCER_URLS
+    unset DATABASE_URL
+    unset DATABASE_2_URL
+    rm -rf "$PGBOUNCER_CONFIG_DIR"
+}
+
+@test "returns exit code of 1 when PGBOUNCER_URLS is empty" {
+    run bash bin/gen-pgbouncer-conf.sh
+    assert_failure
+    assert_line 'DATABASE_URL is empty. Exiting...'
+}
+
+@test "returns exit code of 1 if a value in PGBOUNCER_URLS is invalid" {
+    export DATABASE_URL="foobar"
+    run bash bin/gen-pgbouncer-conf.sh
+    assert_failure
+    assert_line 'DATABASE_URL is not a valid PostgresSQL connection string. Exiting...'
+}
+
+@test "successfully writes the config" {
+    export DATABASE_URL="postgres://user:pass@host:5432/name?query"
+    export DATABASE_2_URL="postgresql://user2:pass@host2:7777/dbname"
+    export PGBOUNCER_URLS="DATABASE_URL DATABASE_2_URL"
+    run bash bin/gen-pgbouncer-conf.sh
+    assert_success
+    cat "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
+    assert_line 'Setting DATABASE_URL_PGBOUNCER config var'
+    assert grep "server_tls_sslmode = prefer" "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
+    assert grep "db1= host=host dbname=name?query port=5432" "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
+    assert grep "db2= host=host2 dbname=dbname port=7777" "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
+    assert grep "user" "$PGBOUNCER_CONFIG_DIR/users.txt"
+    assert grep "user2" "$PGBOUNCER_CONFIG_DIR/users.txt"
+}


### PR DESCRIPTION
Invalid config can sneak in, resulting in confusing error messages. This commit attempts to validate entries in `PGBOUNCER_URLS` before passing them to the config. It handles two cases - the empty case, and the invalid PostgreSQL connection string case.

Fixes #171