### PR TITLE
test: add Heroku stack testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,3 +22,12 @@ jobs:
     - uses: actions/checkout@v3
     - name: run bats tests
       run: docker run -t -v "${PWD}:/code" bats/bats:latest test/*.bats
+  test-stack:
+    strategy:
+      matrix:
+        stack: [heroku-18, heroku-20, heroku-22]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: run stack test
+      run: bash test/test-stack.sh ${{ matrix.stack }}

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ## Unreleased
 * Converted our remaining CircleCI tests to Github Actions
 * Add validation for PGBOUNCER_URLS
+* Add stack tests
 
 ## v0.13.0 (September 9, 2022)
 * Update pgbouncer to v1.17.0 for Heroku-18 and Heroku-20 (for parity with Heroku-22)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+
+ARG STACK
+RUN mkdir -p /app /cache /env
+COPY . /buildpack
+# Sanitize the environment seen by the buildpack, to prevent reliance on
+# environment variables that won't be present when it's run by Heroku CI.
+RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/detect /app
+RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/compile /app /cache /env
+
+ENV DATABASE_URL=postgres://user:pass@example.com:5432/postgres
+WORKDIR /app
+RUN bash bin/gen-pgbouncer-conf.sh
+RUN sed -i -e :a -e '$d;N;2,2ba' -e 'P;D' vendor/pgbouncer/pgbouncer.ini
+RUN useradd pgbouncer
+RUN chown pgbouncer -R /app
+USER pgbouncer

--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,7 @@ mkdir -p "$BUILD_DIR/bin"
 mkdir -p "$BUILD_DIR/$VENDORED_PGBOUNCER"
 
 echo "-----> pgbouncer-buildpack: Vendoring pgbouncer into slug"
-tar xzf pgbouncer-"${STACK}".tgz -C "${BUILD_DIR}"/"${VENDORED_PGBOUNCER}"
+tar xzf "$BUILDPACK_DIR/pgbouncer-${STACK}".tgz -C "${BUILD_DIR}"/"${VENDORED_PGBOUNCER}"
 pgbouncer_version=$("${BUILD_DIR}"/"${VENDORED_PGBOUNCER}"/bin/pgbouncer -V 2>&1 | head -1 | awk '{ print $NF }')
 echo "-----> pgbouncer-buildpack: Installed pgbouncer ${pgbouncer_version}"
 

--- a/bin/start-pgbouncer
+++ b/bin/start-pgbouncer
@@ -64,6 +64,10 @@ run-pgbouncer() {
 }
 
 config-gen() {
+  if [ -f "vendor/pgbouncer/pgbouncer.ini" ]
+  then
+    return
+  fi
   # Generate config files
   at config-gen-start
   source bin/gen-pgbouncer-conf.sh

--- a/test/test-stack.sh
+++ b/test/test-stack.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+[ $# -eq 1 ] || { echo "Usage: $0 STACK"; exit 1; }
+
+STACK="${1}"
+BASE_IMAGE="heroku/${STACK/-/:}-build"
+OUTPUT_IMAGE="pgbouncer-test-${STACK}"
+
+echo "Building buildpack on stack ${STACK}..."
+
+docker build \
+    --build-arg STACK="$STACK" \
+    --build-arg BASE_IMAGE="$BASE_IMAGE" \
+    -t "$OUTPUT_IMAGE" \
+    .
+
+echo "Checking pgbouncer presence and version..."
+
+START_BOUNCER="bin/start-pgbouncer psql postgres://:6000/pgbouncer?host=/tmp -tc 'SHOW VERSION;' > bouncer.log 2>&1"
+TEST_COMMAND="$START_BOUNCER && grep 'listening on 127.0.0.1:6000' bouncer.log && grep ' PgBouncer' bouncer.log"
+
+docker run \
+    --rm \
+    -t "$OUTPUT_IMAGE" \
+    bash -c "$TEST_COMMAND" && \
+    echo "Success!"


### PR DESCRIPTION
This commit adds a Dockerfile to build and run the buildpack in a Heroku-like environment to test for compability, and actually execute PgBouncer. It connects over a Unix socket to the management DB and checks the currently running version, then exits.

Additional changes are made to `bin/compile` and `bin/start-pgbouncer` to support this testing.

Fixes #165