### PR TITLE
maint: add verbose logging config var

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 ## Unreleased
 * Converted our remaining CircleCI tests to Github Actions
+* Add PGBOUNCER_LOG_VERBOSE config var.
 
 ## v0.13.0 (September 9, 2022)
 * Update pgbouncer to v1.17.0 for Heroku-18 and Heroku-20 (for parity with Heroku-22)

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Some settings are configurable through app config vars at runtime. Refer to the 
 - `PGBOUNCER_LOG_CONNECTIONS` Default is 1. If your app does not use persistent database connections, this may be noisy and should be set to 0.
 - `PGBOUNCER_LOG_DISCONNECTIONS` Default is 1. If your app does not use persistent database connections, this may be noisy and should be set to 0.
 - `PGBOUNCER_LOG_POOLER_ERRORS` Default is 1
+- `PGBOUNCER_LOG_VERBOSE` Default is 0. Change to 1 or 2 to increase log verbosity.
 - `PGBOUNCER_STATS_PERIOD` Default is 60
 - `PGBOUNCER_SERVER_RESET_QUERY` Default is empty when pool mode is transaction, and "DISCARD ALL;" when session.
 - `PGBOUNCER_IGNORE_STARTUP_PARAMETERS` Adds parameters to ignore when pgbouncer is starting. Some postgres libraries, like Go's pq, append this parameter, making it impossible to use this buildpack. Default is empty and the most common ignored parameter is `extra_float_digits`. Multiple parameters can be seperated via commas. Example: `PGBOUNCER_IGNORE_STARTUP_PARAMETERS="extra_float_digits, some_other_param"`

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -40,6 +40,7 @@ log_pooler_errors = ${PGBOUNCER_LOG_POOLER_ERRORS:-1}
 stats_period = ${PGBOUNCER_STATS_PERIOD:-60}
 ignore_startup_parameters = ${PGBOUNCER_IGNORE_STARTUP_PARAMETERS}
 query_wait_timeout = ${PGBOUNCER_QUERY_WAIT_TIMEOUT:-120}
+verbose = ${PGBOUNCER_LOG_VERBOSE:-0}
 
 [databases]
 EOFEOF


### PR DESCRIPTION
This commits adds `PGBOUNCER_LOG_VERBOSE` as a config var, with a default value of 0. This allows controlling of log verbosity for debugging purposes.