### PR TITLE
maint: enable SCRAM support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 ## Unreleased
 * Support SCRAM authentication, use plain passwords in auth_file
+* Add PGBOUNCER_AUTH_TYPE config and update default to scram-sha-256
+* Add PGBOUNCER_SERVER_TLS_SSLMODE config and update default to require
+* Update server_tls_sslmode to require (from prefer)
 
 ## v0.14.0 (May 20, 2024)
 * Converted our remaining CircleCI tests to Github Actions

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 ## Unreleased
+* Support SCRAM authentication, use plain passwords in auth_file
 
 ## v0.14.0 (May 20, 2024)
 * Converted our remaining CircleCI tests to Github Actions

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ your leader as a read-only replica, potentially doubling your connection count.
 Some settings are configurable through app config vars at runtime. Refer to the appropriate documentation for
 [pgbouncer](https://pgbouncer.github.io/config.html) configurations to see what settings are right for you.
 
+- `PGBOUNCER_AUTH_TYPE` Default is `scram-sha-256`. Can be changed to `md5` or `plain` depending on server support.
+- `PGBOUNCER_SERVER_TLS_SSLMODE` Default is `require`.
 - `PGBOUNCER_POOL_MODE` Default is transaction
 - `PGBOUNCER_MAX_CLIENT_CONN` Default is 100
 - `PGBOUNCER_DEFAULT_POOL_SIZE` Default is 1

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -19,9 +19,9 @@ cat >> "$CONFIG_DIR/pgbouncer.ini" << EOFEOF
 [pgbouncer]
 listen_addr = 127.0.0.1
 listen_port = 6000
-auth_type = md5
+auth_type = scram-sha-256
 auth_file = $CONFIG_DIR/users.txt
-server_tls_sslmode = prefer
+server_tls_sslmode = require
 server_tls_protocols = secure
 server_tls_ciphers = HIGH:!ADH:!AECDH:!LOW:!EXP:!MD5:!3DES:!SRP:!PSK:@STRENGTH
 
@@ -72,8 +72,6 @@ do
     fi
   done
 
-  DB_MD5_PASS="md5"$(echo -n "${DB_PASS}""${DB_USER}" | md5sum | awk '{print $1}')
-
   CLIENT_DB_NAME="db${n}"
 
   echo "Setting ${POSTGRES_URL}_PGBOUNCER config var"
@@ -86,7 +84,7 @@ do
   fi
 
   cat >> "$CONFIG_DIR/users.txt" << EOFEOF
-"$DB_USER" "$DB_MD5_PASS"
+"$DB_USER" "$DB_PASS"
 EOFEOF
 
   cat >> "$CONFIG_DIR/pgbouncer.ini" << EOFEOF

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -19,9 +19,9 @@ cat >> "$CONFIG_DIR/pgbouncer.ini" << EOFEOF
 [pgbouncer]
 listen_addr = 127.0.0.1
 listen_port = 6000
-auth_type = scram-sha-256
+auth_type = ${PGBOUNCER_AUTH_TYPE:-scram-sha-256}
 auth_file = $CONFIG_DIR/users.txt
-server_tls_sslmode = require
+server_tls_sslmode = ${PGBOUNCER_SERVER_TLS_SSLMODE:-require}
 server_tls_protocols = secure
 server_tls_ciphers = HIGH:!ADH:!AECDH:!LOW:!EXP:!MD5:!3DES:!SRP:!PSK:@STRENGTH
 

--- a/test/gen-pgbouncer-conf.bats
+++ b/test/gen-pgbouncer-conf.bats
@@ -34,7 +34,8 @@ teardown_file() {
     assert_success
     cat "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
     assert_line 'Setting DATABASE_URL_PGBOUNCER config var'
-    assert grep "server_tls_sslmode = prefer" "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
+    assert grep "auth_type = scram-sha-256" "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
+    assert grep "server_tls_sslmode = require" "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
     assert grep "db1= host=host dbname=name?query port=5432" "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
     assert grep "db2= host=host2 dbname=dbname port=7777" "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
     assert grep "user" "$PGBOUNCER_CONFIG_DIR/users.txt"

--- a/test/gen-pgbouncer-conf.bats
+++ b/test/gen-pgbouncer-conf.bats
@@ -28,7 +28,7 @@ teardown_file() {
 
 @test "successfully writes the config" {
     export DATABASE_URL="postgres://user:pass@host:5432/name?query"
-    export DATABASE_2_URL="postgresql://user2:pass@host2:7777/dbname"
+    export DATABASE_2_URL="postgresql://user2:pass2@host2:7777/dbname"
     export PGBOUNCER_URLS="DATABASE_URL DATABASE_2_URL"
     run bash bin/gen-pgbouncer-conf.sh
     assert_success
@@ -38,6 +38,24 @@ teardown_file() {
     assert grep "server_tls_sslmode = require" "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
     assert grep "db1= host=host dbname=name?query port=5432" "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
     assert grep "db2= host=host2 dbname=dbname port=7777" "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
-    assert grep "user" "$PGBOUNCER_CONFIG_DIR/users.txt"
-    assert grep "user2" "$PGBOUNCER_CONFIG_DIR/users.txt"
+    assert grep "\"user\" \"pass\"" "$PGBOUNCER_CONFIG_DIR/users.txt"
+    assert grep "\"user2\" \"pass2\"" "$PGBOUNCER_CONFIG_DIR/users.txt"
+}
+
+@test "successfully allows changing of auth_type" {
+    export DATABASE_URL="postgres://user:pass@host:5432/name?query"
+    export PGBOUNCER_AUTH_TYPE="md5"
+    run bash bin/gen-pgbouncer-conf.sh
+    assert_success
+    cat "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
+    assert grep "auth_type = md5" "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
+}
+
+@test "successfully allows changing of server_tls_sslmode" {
+    export DATABASE_URL="postgres://user:pass@host:5432/name?query"
+    export PGBOUNCER_SERVER_TLS_SSLMODE="prefer"
+    run bash bin/gen-pgbouncer-conf.sh
+    assert_success
+    cat "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
+    assert grep "server_tls_sslmode = prefer" "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
 }


### PR DESCRIPTION
In order to support SCRAM support for the new Heroku Postgres "Essential" plans, we need to shift from MD5 hashed passwords in `auth_file` to plain text. This does not materially change the threat model, as anyone with dyno access can read the passwords from the environment just as well as the file.

See: https://www.pgbouncer.org/config.html#authentication-file-format for more.

This commit switches the `auth_type` to `scram-sha-256` and also pushes `server_tls_sslmode` up to `require` over `prefer`.

Why not use a method like `auth_query`? Exposing something like `pg_authid` or `pg_shadow` in a safe way via a `SECURITY DEFINER` function is extremely challenging in a multi-tenant environment. This may change in the future.

Fixes #155.

Ref: https://gus.my.salesforce.com/a07EE00001rjvVBYAY

Testing Notes:
- Deploy an application to Heroku that connects to an Essential-tier Postgres instance and inserts random numbers into a test table
-  Add this branch's version of the buildpack with `heroku buildpacks:add https://github.com/heroku/heroku-buildpack-pgbouncer.git#17cb11aa1ebabf5d467cb6341c8dfc155533a326`
- Build the app
- Tail the app logs:
```
2024-05-21T14:00:58.410834+00:00 app[conn_test.1]: 2024-05-21 14:00:58.410 UTC [16] LOG S-0x565551b1bb80: db1/u4ifhuflluntg3@54.147.31.50:5432 new connection to server (from 172.16.0.66:44670)
2024-05-21T14:00:58.416864+00:00 app[conn_test.1]: 2024-05-21 14:00:58.416 UTC [16] LOG S-0x565551b1bb80: db1/u4ifhuflluntg3@54.147.31.50:5432 SSL established: TLSv1.3/TLS_AES_256_GCM_SHA384/ECDH=prime256v1
2024-05-21T14:00:59.385069+00:00 app[conn_test.1]: thread id 4 starting..
2024-05-21T14:00:59.385879+00:00 app[conn_test.1]: 2024-05-21 14:00:59.385 UTC [16] LOG C-0x565551b15800: db1/u4ifhuflluntg3@127.0.0.1:50376 login attempt: db=db1 user=u4ifhuflluntg3 tls=no
2024-05-21T14:01:02.385909+00:00 app[conn_test.1]: thread id 5 starting..
2024-05-21T14:01:02.386555+00:00 app[conn_test.1]: 2024-05-21 14:01:02.386 UTC [16] LOG C-0x565551b14ae0: db1/u4ifhuflluntg3@127.0.0.1:52666 closing because: client close request (age=21s)
```