### PR TITLE
Prepare buildpack release v0.16.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## v0.16.0 (August 5, 2024)
+## v0.16.0 (August 13, 2024)
 * Update pgbouncer to v1.23.1
 
 ## v0.15.0 (May 23, 2024)


### PR DESCRIPTION
To pick up #195.

https://github.com/heroku/heroku-buildpack-pgbouncer/compare/v0.15.0...a68bddc34256a0e518085f8b5a63d8b988fde997