### PR TITLE
feat: add support for uri-encoded user/pass

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 ## Unreleased
 * Add Dependabot configuration
+* Add handling for URI-encoded user/pass (@zyv)
 
 ## v0.16.0 (August 13, 2024)
 * Update pgbouncer to v1.23.1

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -48,6 +48,8 @@ query_wait_timeout = ${PGBOUNCER_QUERY_WAIT_TIMEOUT:-120}
 [databases]
 EOFEOF
 
+function urldecode() { : "${*//+/ }"; echo -e "${_//%/\\x}"; }
+
 for POSTGRES_URL in $POSTGRES_URLS
 do
   eval POSTGRES_URL_VALUE="\$$POSTGRES_URL"
@@ -72,6 +74,9 @@ do
     fi
   done
 
+  DECODED_DB_USER="$(urldecode "$DB_USER")"
+  DECODED_DB_PASS="$(urldecode "$DB_PASS")"
+
   CLIENT_DB_NAME="db${n}"
 
   echo "Setting ${POSTGRES_URL}_PGBOUNCER config var"
@@ -84,7 +89,7 @@ do
   fi
 
   cat >> "$CONFIG_DIR/users.txt" << EOFEOF
-"$DB_USER" "$DB_PASS"
+"$DECODED_DB_USER" "$DECODED_DB_PASS"
 EOFEOF
 
   cat >> "$CONFIG_DIR/pgbouncer.ini" << EOFEOF

--- a/test/gen-pgbouncer-conf.bats
+++ b/test/gen-pgbouncer-conf.bats
@@ -59,3 +59,10 @@ teardown_file() {
     cat "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
     assert grep "server_tls_sslmode = prefer" "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
 }
+
+@test "successfully handles URI-encoded user/pass combinations" {
+    export DATABASE_URL="postgresql://%22I+have+speci%40l+charcters%22:c00lp%40%25sword@host:5432/name?query"
+    run bash bin/gen-pgbouncer-conf.sh
+    assert_success
+    assert grep '""I have speci@l charcters"" "c00lp@%sword"' "$PGBOUNCER_CONFIG_DIR/users.txt"
+}


### PR DESCRIPTION
With much thanks to @zyv, this commit adds support for URI-encoded user/pass combinations. We decode URI-encoded user/pass combinations for use in `users.txt`, but keep the encoded versions for the exported pgBouncer URIs.

Ref: https://github.com/heroku/heroku-buildpack-pgbouncer/pull/139