### PR TITLE
Add `PGBOUNCER_MAX_PREPARED_STATEMENTS` config

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ## Unreleased
 * Add Dependabot configuration
 * Add handling for URI-encoded user/pass (@zyv)
+* Add PGBOUNCER_MAX_PREPARED_STATEMENTS config with default of 0 (@habovh)
 
 ## v0.16.0 (August 13, 2024)
 * Update pgbouncer to v1.23.1

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Some settings are configurable through app config vars at runtime. Refer to the 
 - `PGBOUNCER_AUTH_TYPE` Default is `scram-sha-256`. Can be changed to `md5` or `plain` depending on server support.
 - `PGBOUNCER_SERVER_TLS_SSLMODE` Default is `require`.
 - `PGBOUNCER_POOL_MODE` Default is transaction
+- `PGBOUNCER_MAX_PREPARED_STATEMENTS` Default is 0
 - `PGBOUNCER_MAX_CLIENT_CONN` Default is 100
 - `PGBOUNCER_DEFAULT_POOL_SIZE` Default is 1
 - `PGBOUNCER_MIN_POOL_SIZE` Default is 0

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ connection limits and Out Of Memory errors on the Postgres server.
 - A: You have many workers per dyno that hold open idle Postgres connections and you want to reduce the number of unused connections. [This is a slightly more complete answer from stackoverflow](http://stackoverflow.com/questions/12189162/what-are-advantages-of-using-transaction-pooling-with-pgbouncer)
 
 - Q: Why shouldn't I use transaction pooling?
-- A: If you need to use named prepared statements, advisory locks, listen/notify, or other features that operate on a session level.
+- A: If you need to use advisory locks, listen/notify, or other features that operate on a session level.
 Please refer to PGBouncer's [feature matrix](https://www.pgbouncer.org/features.html#sql-feature-map-for-pooling-modes) for all transaction pooling caveats.
 
 

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -31,6 +31,7 @@ server_tls_ciphers = HIGH:!ADH:!AECDH:!LOW:!EXP:!MD5:!3DES:!SRP:!PSK:@STRENGTH
 ;   statement    - after statement finishes
 pool_mode = ${POOL_MODE}
 server_reset_query = ${SERVER_RESET_QUERY}
+max_prepared_statements = ${PGBOUNCER_MAX_PREPARED_STATEMENTS:-0}
 max_client_conn = ${PGBOUNCER_MAX_CLIENT_CONN:-100}
 default_pool_size = ${PGBOUNCER_DEFAULT_POOL_SIZE:-1}
 min_pool_size = ${PGBOUNCER_MIN_POOL_SIZE:-0}

--- a/test/gen-pgbouncer-conf.bats
+++ b/test/gen-pgbouncer-conf.bats
@@ -60,6 +60,15 @@ teardown_file() {
     assert grep "server_tls_sslmode = prefer" "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
 }
 
+@test "successfully allows changing of max_prepared_statements" {
+    export DATABASE_URL="postgres://user:pass@host:5432/name?query"
+    export PGBOUNCER_MAX_PREPARED_STATEMENTS="123"
+    run bash bin/gen-pgbouncer-conf.sh
+    assert_success
+    cat "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
+    assert grep "max_prepared_statements = 123" "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
+}
+
 @test "successfully handles URI-encoded user/pass combinations" {
     export DATABASE_URL="postgresql://%22I+have+speci%40l+charcters%22:c00lp%40%25sword@host:5432/name?query"
     run bash bin/gen-pgbouncer-conf.sh


### PR DESCRIPTION
Following issues I had when using this buildpack with Prisma ORM and prepared statements, I am suggesting these changes to add support for `max_prepared_statements` configuration on pgbouncer.

As it turns out, it seems that if not set, the default value would be 0. This is an issue when using transaction pooling mode, and prevents from using prepared statements in that case.

Giving control to the user on this important configuration seems appropriate, keeping the default value at zero to avoid breaking changes, basically making it an opt-in config.

I updated the *.tgz files but I'm not sure this was needed as I'm not familiar with how build packs work, maybe the changes to `bin/gen-pgbouncer-conf.sh` were enough. Let me know so I can update my branch accordingly.

Relevant issues:
- Update to more recent pgbouncer to support prepared statements
  - https://github.com/heroku/heroku-buildpack-pgbouncer/issues/182
- Prisma issue with prepared statements
  - https://github.com/prisma/prisma/issues/21877