### PR TITLE
Fix changelog check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: "daily"
     labels:
       - "dependencies"
+      - "skip changelog"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
       - name: Check that Changelog.md is touched
         run: |
           git fetch origin ${{ github.base_ref }} --depth 1 && \

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,22 @@
+name: Check Changelog
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  check-changelog:
+    runs-on: ubuntu-24.04
+    if: (!contains(github.event.pull_request.labels.*.name, 'skip changelog'))
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Check that Changelog.md is touched
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth 1 && \
+          git diff remotes/origin/${{ github.base_ref }} --name-only | grep Changelog.md

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,15 +7,6 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 jobs:
-  check_changelog:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Check that CHANGELOG is touched
-      run: |
-        cat $GITHUB_EVENT_PATH | jq .pull_request.title |  grep -i '\[\(\(changelog skip\)\|\(ci skip\)\)\]' ||  git diff remotes/origin/${{ github.base_ref }} --name-only | grep Changelog.md
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The changelog check is currently configured to run on pushes to `main`, where it always fails because `github.base_ref` is not available.

This moves the changelog check to its own workflow and makes it conditional on the absence of a "`check changelog`" label, which dependabot now also sets on its PRs.

GUS-W-21054697