### PR TITLE
chore: add heroku data to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,4 @@
 # Comment line immediately above ownership line is reserved for related gus information. Please be careful while editing.
 #ECCN:Open Source
+#GUSINFO:Heroku Data Operations,Heroku Data Intake
+* @heroku/data


### PR DESCRIPTION
This pr updates the codeowners file to signal heroku data's ownership of this repository. H/t @edmorley  for the find 🫡 

Slack context: https://salesforce.enterprise.slack.com/archives/C1N6YD1PG/p1774280079957619