### PR TITLE
Add PGBOUNCER_CONNECT_QUERY config

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.20.0 (Unreleased)
+
+* Add `PGBOUNCER_CONNECT_QUERY` config for per-database connect_query
+
 ## v0.19.0 (May 20, 2026)
 
 * Update pgbouncer to v1.25.1

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.20.0 (Unreleased)
+## v0.20.0 (June 8, 2026)
 
 * Add `PGBOUNCER_CONNECT_QUERY` config for per-database connect_query
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Some settings are configurable through app config vars at runtime. Refer to the 
 - `PGBOUNCER_SERVER_RESET_QUERY` Default is empty when pool mode is transaction, and "DISCARD ALL;" when session.
 - `PGBOUNCER_IGNORE_STARTUP_PARAMETERS` Adds parameters to ignore when pgbouncer is starting. Some postgres libraries, like Go's pq, append this parameter, making it impossible to use this buildpack. Default is empty and the most common ignored parameter is `extra_float_digits`. Multiple parameters can be seperated via commas. Example: `PGBOUNCER_IGNORE_STARTUP_PARAMETERS="extra_float_digits, some_other_param"`
 - `PGBOUNCER_QUERY_WAIT_TIMEOUT` Default is 120 seconds, helps when the server is down or the database rejects connections for any reason. If this is disabled, clients will be queued infinitely.
+- `PGBOUNCER_CONNECT_QUERY` Default is empty. Query to be executed after a connection is established, but before allowing the connection to be used by any clients. Useful for setting session-level parameters like `statement_timeout`.
 
 For more info, see [CONTRIBUTING.md](CONTRIBUTING.md)
 

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -96,8 +96,13 @@ do
 "$DECODED_DB_USER" "$DECODED_DB_PASS"
 EOFEOF
 
+  CONNECT_QUERY_PARAM=''
+  if [ -n "${PGBOUNCER_CONNECT_QUERY:-}" ]; then
+    CONNECT_QUERY_PARAM="connect_query='${PGBOUNCER_CONNECT_QUERY//\'/''}'"
+  fi
+
   cat >> "$CONFIG_DIR/pgbouncer.ini" << EOFEOF
-$CLIENT_DB_NAME= host=$DB_HOST dbname=$DB_NAME port=$DB_PORT
+$CLIENT_DB_NAME= host=$DB_HOST dbname=$DB_NAME port=$DB_PORT $CONNECT_QUERY_PARAM
 EOFEOF
 
   (( n += 1 ))

--- a/test/gen-pgbouncer-conf.bats
+++ b/test/gen-pgbouncer-conf.bats
@@ -6,6 +6,10 @@ setup_file() {
     export PGBOUNCER_CONFIG_DIR=$(mktemp -d run-test-pgbouncer.XXXXXXXXXX)
 }
 
+setup() {
+    rm -f "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini" "$PGBOUNCER_CONFIG_DIR/users.txt"
+}
+
 teardown_file() {
     unset PGBOUNCER_URLS
     unset DATABASE_URL
@@ -74,4 +78,20 @@ teardown_file() {
     run bash bin/gen-pgbouncer-conf.sh
     assert_success
     assert grep '""I have speci@l charcters"" "c00lp@%sword"' "$PGBOUNCER_CONFIG_DIR/users.txt"
+}
+
+@test "successfully adds connect_query when PGBOUNCER_CONNECT_QUERY is set" {
+    export DATABASE_URL="postgres://user:pass@host:5432/name"
+    export PGBOUNCER_CONNECT_QUERY="SET statement_timeout = 30000"
+    run bash bin/gen-pgbouncer-conf.sh
+    assert_success
+    assert grep "connect_query='SET statement_timeout = 30000'" "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
+}
+
+@test "does not add connect_query when PGBOUNCER_CONNECT_QUERY is not set" {
+    export DATABASE_URL="postgres://user:pass@host:5432/name"
+    unset PGBOUNCER_CONNECT_QUERY
+    run bash bin/gen-pgbouncer-conf.sh
+    assert_success
+    refute grep "connect_query" "$PGBOUNCER_CONFIG_DIR/pgbouncer.ini"
 }


### PR DESCRIPTION
## Summary

Adds support for `PGBOUNCER_CONNECT_QUERY` — SQL query executed on each new server connection. This allows setting session-level parameters (like `statement_timeout`) that persist across pgbouncer backend rotations.

When pgbouncer rotates backends, any session-level settings established by the application's connection hook are lost on the new backend. `connect_query` is pgbouncer's native mechanism to re-apply these settings on every new server connection.

## Testing

- [x] BATS tests pass locally
- [x] Deploy to dev with `PGBOUNCER_CONNECT_QUERY="SET statement_timeout = 30000"` and verify generated ini
- [x] Confirm `statement_timeout` persists after backend rotation

### Dev testing results

Deployed to dev with branch buildpack, `PGBOUNCER_CONNECT_QUERY="SET statement_timeout = 30000"`, and `PGBOUNCER_SERVER_LIFETIME=10`.

**Verify generated ini:**
```
$ grep connect_query /app/vendor/pgbouncer/pgbouncer.ini
db1= host=<redacted> dbname=<redacted> port=5432 connect_query='SET statement_timeout = 30000'
```

**Verify timeout active on running web dyno:**
```
DB['SHOW statement_timeout'].first
=> {statement_timeout: "30s"}
```

**Verify persistence after backend rotation:**
```ruby
results = []
DB.disconnect
pid = DB.fetch("SELECT pg_backend_pid() as pid").first[:pid]
timeout = DB.fetch("SHOW statement_timeout").first[:statement_timeout]
results << { i: 0, pid: pid, timeout: timeout }
DB.disconnect
sleep(12)
pid = DB.fetch("SELECT pg_backend_pid() as pid").first[:pid]
timeout = DB.fetch("SHOW statement_timeout").first[:statement_timeout]
results << { i: 1, pid: pid, timeout: timeout }
results
```

After the fix: `[{i: 0, pid: 2351515, timeout: "30s"}, {i: 1, pid: 2351534, timeout: "30s"}]`

Different PIDs confirm the backend rotated after `server_lifetime=10s`. `statement_timeout` persists on the new connection via `connect_query`.

**Verified unset PGBOUNCER_CONNECT_QUERY has no functional change**
**Verified invalid SQL in PGBOUNCER_CONNECT_QUERY does not break connections**

## Post-merge steps

1. Tag and release:
   ```bash
   git checkout main && git pull origin main
   git tag v0.20.0
   git push origin v0.20.0
   gh release create v0.20.0 --title "v0.20.0" --notes "## What's Changed

   * Add PGBOUNCER_CONNECT_QUERY config for per-database connect_query

   **Full Changelog**: https://github.com/heroku/heroku-buildpack-pgbouncer/compare/v0.19.0...v0.20.0"
   ```
2. Publish to buildpack registry:
   ```bash
   heroku buildpacks:publish heroku/pgbouncer v0.20.0
   ```